### PR TITLE
Prevent undefined variable access

### DIFF
--- a/dist/core/scrollbugfix/mmenu.scrollbugfix.js
+++ b/dist/core/scrollbugfix/mmenu.scrollbugfix.js
@@ -74,11 +74,17 @@ export default function () {
     //	Scroll the current opened panel to the top when opening the menu.
     this.bind('open:start', function () {
         var panel = DOM.children(_this.node.pnls, '.mm-panel_opened')[0];
+        if (!panel) {
+            return;
+        }
         panel.scrollTop = 0;
     });
     //	Fix issue after device rotation change.
     window.addEventListener('orientationchange', function (evnt) {
         var panel = DOM.children(_this.node.pnls, '.mm-panel_opened')[0];
+        if (!panel) {
+            return;
+        }
         panel.scrollTop = 0;
         //	Apparently, changing the overflow-scrolling property triggers some event :)
         panel.style['-webkit-overflow-scrolling'] = 'auto';

--- a/src/core/scrollbugfix/mmenu.scrollbugfix.ts
+++ b/src/core/scrollbugfix/mmenu.scrollbugfix.ts
@@ -93,12 +93,18 @@ export default function(this: Mmenu) {
     //	Scroll the current opened panel to the top when opening the menu.
     this.bind('open:start', () => {
         var panel = DOM.children(this.node.pnls, '.mm-panel_opened')[0];
+        if (!panel) {
+            return;
+        }
         panel.scrollTop = 0;
     });
 
     //	Fix issue after device rotation change.
     window.addEventListener('orientationchange', evnt => {
         var panel = DOM.children(this.node.pnls, '.mm-panel_opened')[0];
+        if (!panel) {
+            return;
+        }
         panel.scrollTop = 0;
 
         //	Apparently, changing the overflow-scrolling property triggers some event :)


### PR DESCRIPTION
I faced a problem after upgrading from version 7 to 8: the panel variable is undefined in one of our scenarios. I don't know what causes it, but I suppose that's because `open:start` event is intercepted before `mm-panel_opened` class is applied.

I added the same variable check in `orientationchange` event handle, even though I'm still not sure if it's possible there too. But IMO that's not a big tradeoff to check the variable existence since it actually can be undefined.