### PR TITLE
Bug with taping on title (in older than 8.4.3 tap on title will return)

### DIFF
--- a/src/addons/navbars/_navbar.title.ts
+++ b/src/addons/navbars/_navbar.title.ts
@@ -24,7 +24,9 @@ export default function(this: Mmenu, navbar: HTMLElement) {
             '.' + this.conf.classNames.navbars.panelTitle
         );
         if (!original) {
-            original = panel.querySelector('.mm-navbar__title span');
+            // Remove span, this cause bug with returning with tap on title
+            // Below we trying to get 'href' attribute on span and it's a bug
+            original = panel.querySelector('.mm-navbar__title');
         }
 
         //	Get the URL for the title.


### PR DESCRIPTION
8.4.2 was oldest version with working tap on title - then back to previous.
After update to newest version I have problem with that so I found this bug.
Cheers!