### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name"			: "FrDH/mmenu.js",
+	"name"			: "frdh/mmenu.js",
 	"version"		: "8.4.7",
 	"authors"		: [{
 		"name"			: "Fred Heusschen",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name"			: "mmenu.js",
+	"name"			: "FrDH/mmenu.js",
 	"version"		: "8.4.7",
 	"authors"		: [{
 		"name"			: "Fred Heusschen",


### PR DESCRIPTION
From Packagist.org:
Deprecation warning: require.mmenu.js is invalid, it should have a vendor name, a forward slash, and a package name. The vendor and package name can be words separated by -, . or _. The complete name should match `[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9]([_.-]?[a-z0-9]+)*`. Make sure you fix this as Composer 2.0 will error.